### PR TITLE
Fix typo in comment

### DIFF
--- a/app.py
+++ b/app.py
@@ -172,7 +172,7 @@ def scan_and_convert(directory, library_section_id):
                 if convert_file(full_path):
                     trigger_plex_scan(library_section_id)
                     time.sleep(10)
-#something differant
+# something different
 
 if __name__ == "__main__":
     while True:


### PR DESCRIPTION
## Summary
- correct a typo in `app.py` near the cleanup code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68434aec36fc8326ba5a55ac06d6572e