### PR TITLE
Remove duplicate plex scan call

### DIFF
--- a/app.py
+++ b/app.py
@@ -139,7 +139,6 @@ def convert_file(src_path):
         print(f"✅ Converted successfully: {new_name}")
         os.remove(src_path)
         os.replace(temp_output, final_output)
-        trigger_plex_scan(2)
         return True
     except subprocess.CalledProcessError:
         print(f"❌ Conversion failed: {src_path}")


### PR DESCRIPTION
## Summary
- avoid scanning Plex automatically from `convert_file`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68434ac7f3848326b7bdef307230b287