### PR TITLE
Add audio copy option and bitrate flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # convert-media
+
+A simple script that scans movie directories and converts incompatible files using ffmpeg.
+
+## Usage
+
+```bash
+python app.py [--copy-audio] [--audio-bitrate 320k]
+```
+
+- `--copy-audio`: Preserve existing audio streams when already in a supported format (`aac` or `ac3`).
+- `--audio-bitrate`: Bitrate to use when re-encoding audio (defaults to `160k`).
+
+The script continuously monitors the configured directories and converts files as needed.


### PR DESCRIPTION
## Summary
- preserve existing audio when codec already supported with `--copy-audio`
- allow custom audio bitrate via `--audio-bitrate`
- document usage in README
- clean up requirements file revert

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68434ae28d5883268a84507c8c257eee